### PR TITLE
update UI added border red on error on dark mode

### DIFF
--- a/components/account/utils/EnrichInput.vue
+++ b/components/account/utils/EnrichInput.vue
@@ -45,7 +45,7 @@ const updateValue = (event: Event) => {
 <template>
 
     <div class="px-6 border border-gray-400/20 dark:border-gray-100/20 font-adaptive flex flex-col justify-start rounded-sm lg:col-span-2"
-         :class="`${disabled ? 'bg-gray-100 dark:bg-gray-700 py-3' : 'bg-white dark:bg-gray-800 py-1'} ${isError ? 'border-red-400' : ''}`"
+         :class="`${disabled ? 'bg-gray-100 dark:bg-gray-700 py-3' : 'bg-white dark:bg-gray-800 py-1'} ${isError ? 'border-red-400 dark:border-red-500' : ''}`"
          @click="focusInput"
     >
         <span class="text-xs text-orange-400 dark:text-orange-500" :hidden="disabled">{{ label }}</span>


### PR DESCRIPTION
This pull request includes a minor change to the `EnrichInput.vue` component to improve the appearance of the input field when there is an error. The change ensures that the border color is correctly applied in dark mode.

* [`components/account/utils/EnrichInput.vue`](diffhunk://#diff-63f0cfb441f2debc15e1189778dcfbe3d28167bd11fdb766f731201abc6bbfa3L48-R48): Updated the error border color to support dark mode by adding `dark:border-red-500` to the class binding.