### PR TITLE
Fix address form overwriting `store` provided address on form cancellation.

### DIFF
--- a/components/account/address/AddressView.vue
+++ b/components/account/address/AddressView.vue
@@ -5,6 +5,7 @@ import {AddressModal, validateAddress} from "~/modals/address.modal";
 import {useAccountStore} from "~/stores/account.store";
 import type {FormError} from "#ui/types";
 import {useToastService} from "~/composables/useToastService";
+import {deepCopy} from "~/utils/GeneralUtils";
 
 
 const props = defineProps({
@@ -19,7 +20,7 @@ const accountStore = useAccountStore();
 const formOpen = ref(false)
 
 const addressForm = reactive<Address>(
-    props.address
+    deepCopy<Address>(props.address)
 )
 
 const errors = ref<FormError[]>([])

--- a/utils/GeneralUtils.ts
+++ b/utils/GeneralUtils.ts
@@ -187,4 +187,53 @@ const validatePassword = (password: string | undefined): boolean => {
     return password.length >= minLength && !maliciousPattern.test(password);
 };
 
-export {roundedTo2, isEmail, isValidGender, isValidAddressType, isValidAccountType, getActivePageInfo, isNotBlank, clearAddressForm, checkError, validatePassword}
+
+
+/**
+ * Creates a deep copy of the given object.
+ *
+ * This function recursively copies all properties of the input object, ensuring that
+ * nested objects and arrays are also deeply copied. It handles primitive types, Date objects,
+ * arrays, and plain objects. The resulting copy is a new object that is structurally identical
+ * to the input object but does not share any references with it.
+ *
+ * @template T - The type of the input object.
+ * @param obj - The object to be deeply copied.
+ * @returns T - A new object that is a deep copy of the input object.
+ */
+function deepCopy<T>(obj: T): T {
+    // Check if the value is a primitive type
+    if (obj === null || typeof obj !== 'object') {
+        return obj;
+    }
+
+    // Handle Date
+    if (obj instanceof Date) {
+        return new Date(obj.getTime()) as any;
+    }
+
+    // Handle Array
+    if (Array.isArray(obj)) {
+        const arrCopy = [] as any[];
+        for (const item of obj) {
+            arrCopy.push(deepCopy(item));
+        }
+        return arrCopy as any;
+    }
+
+    // Handle Object
+    const objCopy = {} as { [key: string]: any };
+    for (const key in obj) {
+        if (obj.hasOwnProperty(key)) {
+            objCopy[key] = deepCopy(obj[key]);
+        }
+    }
+
+    return objCopy as T;
+}
+
+
+export {
+    roundedTo2, isEmail, isValidGender, isValidAddressType, isValidAccountType,
+    getActivePageInfo, isNotBlank, clearAddressForm, checkError, validatePassword, deepCopy
+}


### PR DESCRIPTION
This pull request introduces a utility function for deep copying objects and updates the address form handling in the `AddressView.vue` component to use this new function. The most important changes include the addition of the `deepCopy` function and its application within the address form.

### New Utility Function:

* Added `deepCopy` function to create a deep copy of objects, ensuring that nested objects and arrays are also deeply copied. (`utils/GeneralUtils.ts`)

### Address Form Handling:

* Imported `deepCopy` in `AddressView.vue` for use in address form handling. (`components/account/address/AddressView.vue`)
* Updated the `addressForm` reactive object to use `deepCopy` to ensure that changes to the form do not affect the original address object. (`components/account/address/AddressView.vue`)